### PR TITLE
Update workflows and docs for new django support, drop support for outdated releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,15 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9']
-        django-version: ['2.2', '3.1', '3.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        django-version: ['3.2', '4.0']
         exclude:
-          - python-version: '3.5'
-            django-version: '3.0'
-          - python-version: '3.5'
-            django-version: '3.1'
-          - python-version: '3.5'
-            django-version: '3.2'
+          - python-version: '3.7'
+            django-version: '4.0'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [1.4.0 - Unreleased]
+### Added
+- Support for Python 3.10
+- Support for Django 4.0
+
+### Removed
+- Support for Django 2.2
+- Support for Django 3.1
+- Support for Python 3.5
+- Support for Python 3.6
 
 ## [1.3.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If your project uses an older verison of Django, you can choose an older version
 
 | This Project | Python Version | Django Version |
 |--------------|----------------|----------------|
+| 1.4.*        | 3.7 - 3.10     | 3.2, 4.0       |
 | 1.3.*        | 3.5 - 3.9      | 2.2, 3.1, 3.2  |
 | 1.2.*        | 3.5 - 3.8      | 2.2, 3.0, 3.1  |
 | 1.1.*        | 2.7, 3.4, 3.5  | 1.8, 1.11      |

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,15 @@ URL = 'https://github.com/anexia-it/anexia-monitoring-django'
 AUTHOR = 'Anexia'
 LICENSE = 'MIT'
 REQUIRED = [
-    'updatable>=0.4.1,<0.5',
+    'updatable>=0.6',
 ]
 CLASSIFIERS = [
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### Added
- Support for Python 3.10
- Support for Django 4.0

### Removed
- Support for Django 2.2
- Support for Django 3.1
- Support for Python 3.5
- Support for Python 3.6