### PR TITLE
Move to updatable 0.7 and asyncio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['3.2', '4.0']
+        django-version: ['3.2', '4.0', '4.1']
         exclude:
           - python-version: '3.7'
             django-version: '4.0'
+          - python-version: '3.7'
+            django-version: '4.1'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.5.0 - Unreleased]
 
 ### Added
--
+- Support for Django 4.1
 
 ### Changed
--
 
-### Removed
--
+- Pin updatable to `>=0.7`
 
 ## [1.4.1]
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ website is alive and working correctly.
 Django Compatibility Matrix
 ---------------------------
 
-If your project uses an older verison of Django, you can choose an older version of this project.
+If your project uses an older version of Django, you can choose an older version of this project.
 
 | This Project | Python Version | Django Version |
 |--------------|----------------|----------------|
+| 1.5.*        | 3.7 - 3.10     | 3.2, 4.0, 4.1  |
 | 1.4.*        | 3.7 - 3.10     | 3.2, 4.0       |
 | 1.3.*        | 3.5 - 3.9      | 2.2, 3.1, 3.2  |
 | 1.2.*        | 3.5 - 3.8      | 2.2, 3.0, 3.1  |

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/anexia-it/anexia-monitoring-django'
 AUTHOR = 'Anexia'
 LICENSE = 'MIT'
 REQUIRED = [
-    'updatable>=0.6,<0.7',
+    'updatable>=0.7',
 ]
 CLASSIFIERS = [
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Uses `updatable>=0.7` and async features for http calls to improve performance:

![image](https://user-images.githubusercontent.com/4420927/177987866-1d6800fe-d744-43f7-b63e-466f727b2a90.png)

- first two runs are on `1.4.1` with about 11s per request
- last two runs are on the new version with about 2.3s per request